### PR TITLE
refactor: centralize logo version constant

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
+import { LOGO_VERSION } from '@/lib/constants'
 import './globals.css'
 
 const inter = Inter({
@@ -43,9 +44,9 @@ export default function RootLayout({
   return (
     <html lang="he" dir="rtl">
       <head>
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-        <link rel="alternate icon" href="/favicon.ico" />
-        <link rel="apple-touch-icon" href="/favicon.svg" />
+        <link rel="icon" href={`/favicon.svg?v=${LOGO_VERSION}`} type="image/svg+xml" />
+        <link rel="alternate icon" href={`/favicon.ico?v=${LOGO_VERSION}`} />
+        <link rel="apple-touch-icon" href={`/favicon.svg?v=${LOGO_VERSION}`} />
         <link rel="manifest" href="/manifest.json" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,16 +1,17 @@
 'use client'
 
 import React, { useCallback, useState } from 'react'
+import { LOGO_VERSION } from '@/lib/constants'
 
 export default function Logo() {
   // Try primary logo, then alternates; cache-bust to avoid stale cached zero-byte assets
   const sources = [
     // New official asset (please place the attached file at public/images/social-money-logo-official.png)
-    '/images/social-money-logo-official.png?v=20250812',
-    '/images/social-money-logo.png?v=20250812',
-    '/images/social-money-logo-new.png?v=20250812',
-  '/images/logo.png?v=20250812',
-  '/images/logo-backup.svg?v=20250812',
+    `/images/social-money-logo-official.png?v=${LOGO_VERSION}`,
+    `/images/social-money-logo.png?v=${LOGO_VERSION}`,
+    `/images/social-money-logo-new.png?v=${LOGO_VERSION}`,
+    `/images/logo.png?v=${LOGO_VERSION}`,
+    `/images/logo-backup.svg?v=${LOGO_VERSION}`,
   ] as const
 
   const [idx, setIdx] = useState(0)

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const LOGO_VERSION = '20250812'


### PR DESCRIPTION
## Summary
- centralize `LOGO_VERSION` constant in `lib/constants`
- use shared logo version in `Logo` component
- version favicon links via shared constant

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c77414d50832182b8bece7e11098a