### PR TITLE
Use Next.js Image for logo

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,30 +1,38 @@
 'use client'
 
+import Image from 'next/image'
 import React, { useCallback, useState } from 'react'
+
+// All candidate logo paths
+const sources = [
+  // New official asset (please place the attached file at public/images/social-money-logo-official.png)
+  '/images/social-money-logo-official.png?v=20250812',
+  '/images/social-money-logo.png?v=20250812',
+  '/images/social-money-logo-new.png?v=20250812',
+  '/images/logo.png?v=20250812',
+  '/images/logo-backup.svg?v=20250812',
+] as const
 
 export default function Logo() {
   // Try primary logo, then alternates; cache-bust to avoid stale cached zero-byte assets
-  const sources = [
-    // New official asset (please place the attached file at public/images/social-money-logo-official.png)
-    '/images/social-money-logo-official.png?v=20250812',
-    '/images/social-money-logo.png?v=20250812',
-    '/images/social-money-logo-new.png?v=20250812',
-  '/images/logo.png?v=20250812',
-  '/images/logo-backup.svg?v=20250812',
-  ] as const
-
   const [idx, setIdx] = useState(0)
-  const handleError = useCallback(() => setIdx((i) => Math.min(i + 1, sources.length - 1)), [])
+  const handleError = useCallback(
+    () => setIdx((i) => Math.min(i + 1, sources.length - 1)),
+    [sources.length],
+  )
 
   return (
-    <img
+    <Image
       src={sources[idx]}
+      width={256}
+      height={40}
       alt="כסף חברתי — הלוגו הרשמי"
       className="select-none h-10 w-auto"
       decoding="async"
       loading="eager"
-      draggable="false"
+      draggable={false}
       onError={handleError}
+      priority
     />
   )
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,13 @@ const nextConfig: NextConfig = {
   assetPrefix:
     envAssetPrefix && envAssetPrefix !== '/' ? envAssetPrefix : undefined,
   reactStrictMode: true,
+  images: {
+    dangerouslyAllowSVG: true,
+    remotePatterns: [
+      { protocol: 'https', hostname: '**' },
+      { protocol: 'http', hostname: '**' },
+    ],
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- replace legacy `<img>` tag with Next.js `Image` component for the application logo
- allow any remote logo domain and SVG images via Next.js config

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`
- `npm run stylelint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689c774475148321980d05e220377f38