### PR TITLE
fix: remove remote font fetch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,6 @@
 import type { Metadata, Viewport } from 'next'
-import { Inter } from 'next/font/google'
 import { LOGO_VERSION } from '@/lib/constants'
 import './globals.css'
-
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-})
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -52,7 +46,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="כסף חברתי" />
       </head>
-      <body className={`${inter.className} antialiased bg-gray-50`}>
+      <body className="font-sans antialiased bg-gray-50">
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-blue-600 text-white px-4 py-2 rounded-lg"


### PR DESCRIPTION
## Summary
- avoid build failure by removing Google font and relying on Tailwind's default sans-serif stack

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run stylelint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cce2f7b64832189fba123095b1a9d