### PR TITLE
Add mortgage rates board to refinance calculator

### DIFF
--- a/app/calculators/mortgage-refinance/page.tsx
+++ b/app/calculators/mortgage-refinance/page.tsx
@@ -1,15 +1,15 @@
 import Layout from '@/components/Layout'
 import MortgageRefinanceCalculator from '@/components/calculators/MortgageRefinanceCalculator'
 import HowItWorks from '@/components/HowItWorks'
+import RatesBoard from '@/components/RatesBoard'
 
 export default function MortgageRefinancePage() {
   return (
     <Layout>
       <div dir="rtl" className="max-w-screen-md mx-auto p-4">
+        <RatesBoard />
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-4">
-            מחשבון מחזור משכנתא
-          </h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">מחשבון מחזור משכנתא</h1>
           <p className="text-lg text-gray-600">
             בדקו אם כדאי לכם לבצע מחזור משכנתא וכמה תוכלו לחסוך
           </p>
@@ -32,8 +32,7 @@ export default function MortgageRefinancePage() {
               },
               {
                 title: 'שלב 3 – הצעת תמהיל חדש',
-                detail:
-                  'חשב ריביות עדכניות, החזר חודשי, עלות כוללת, ותרחישים (עליית ריבית/מדד).',
+                detail: 'חשב ריביות עדכניות, החזר חודשי, עלות כוללת, ותרחישים (עליית ריבית/מדד).',
               },
               {
                 title: 'שלב 4 – השוואת הצעות',
@@ -42,8 +41,7 @@ export default function MortgageRefinancePage() {
               },
               {
                 title: 'שלב 5 – החלטה וביצוע',
-                detail:
-                  'חשבן חיסכון נטו אחרי כל העלויות. תאם שמאי ורישומים, בצע מעבר מסודר.',
+                detail: 'חשבן חיסכון נטו אחרי כל העלויות. תאם שמאי ורישומים, בצע מעבר מסודר.',
               },
             ]}
             tips={[
@@ -81,9 +79,7 @@ export default function MortgageRefinancePage() {
 
         {/* Additional Tips */}
         <div className="mt-8 bg-green-50 rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-green-900 mb-3">
-            💰 טיפים לחיסכון נוסף:
-          </h3>
+          <h3 className="text-lg font-semibold text-green-900 mb-3">💰 טיפים לחיסכון נוסף:</h3>
           <div className="space-y-2 text-green-800">
             <p>• השוו הצעות ממספר בנקים</p>
             <p>• בדקו אפשרות למשכנתא משולבת (ריבית קבועה + משתנה)</p>

--- a/components/RatesBoard.tsx
+++ b/components/RatesBoard.tsx
@@ -1,0 +1,73 @@
+import ratesData from '@/data/rates.json'
+
+interface RatesData {
+  lastUpdated: string
+  boiRate: number
+  primeRate?: number
+  avgMortgage: {
+    linked: { short: number; mid: number; long: number }
+    unlinked: { short: number; mid: number; long: number }
+  }
+}
+
+export default function RatesBoard() {
+  const data = ratesData as RatesData
+  const prime = data.primeRate ?? data.boiRate + 1.5
+
+  return (
+    <div className="mb-6 rounded-lg bg-white p-4 shadow" dir="rtl">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">לוח ריביות משכנתא</h2>
+        <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-600">
+          עודכן לאחרונה: {data.lastUpdated}
+        </span>
+      </div>
+
+      <div className="mb-4 grid grid-cols-2 gap-4 text-center">
+        <div>
+          <p className="text-sm text-gray-600">ריבית בנק ישראל</p>
+          <p className="text-lg font-semibold">{data.boiRate.toFixed(2)}%</p>
+        </div>
+        <div>
+          <p className="text-sm text-gray-600">פריים</p>
+          <p className="text-lg font-semibold">{prime.toFixed(2)}%</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <p className="mb-1 font-medium">מקושרות למדד</p>
+          <ul className="space-y-1">
+            <li>קצר: {data.avgMortgage.linked.short}%</li>
+            <li>בינוני: {data.avgMortgage.linked.mid}%</li>
+            <li>ארוך: {data.avgMortgage.linked.long}%</li>
+          </ul>
+        </div>
+        <div>
+          <p className="mb-1 font-medium">לא מקושרות</p>
+          <ul className="space-y-1">
+            <li>קצר: {data.avgMortgage.unlinked.short}%</li>
+            <li>בינוני: {data.avgMortgage.unlinked.mid}%</li>
+            <li>ארוך: {data.avgMortgage.unlinked.long}%</li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <p className="mb-1 text-xs font-medium">מקורות רשמיים:</p>
+        <ul className="list-disc pr-4 text-xs text-gray-600">
+          <li>
+            <a href="https://www.boi.org.il" target="_blank" rel="noreferrer">
+              בנק ישראל
+            </a>
+          </li>
+          <li>
+            <a href="https://www.gov.il" target="_blank" rel="noreferrer">
+              gov.il
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/data/rates.json
+++ b/data/rates.json
@@ -1,0 +1,9 @@
+{
+  "lastUpdated": "2025-08-13",
+  "boiRate": 4.5,
+  "primeRate": 6.0,
+  "avgMortgage": {
+    "linked": { "short": 3.7, "mid": 3.9, "long": 4.1 },
+    "unlinked": { "short": 4.9, "mid": 5.1, "long": 5.2 }
+  }
+}


### PR DESCRIPTION
## Summary
- add static `rates.json` with Bank of Israel, prime and average mortgage rates
- create `RatesBoard` component showing current rates with last-update badge and official sources
- display `RatesBoard` at the top of the mortgage refinance calculator page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d8b2545d08321bd8a5f0651bbee49