### PR TITLE
chore: configure ESLint for Node scripts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,23 @@
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
+import globals from 'globals'
 
 export default [
   { ignores: ['**/.next/**', '**/node_modules/**', '**/dist/**', '**/build/**', 'jest.setup.js', 'jest.config.js'] },
   js.configs.recommended,
   // TypeScript ESLint recommended (no type-aware rules to simplify setup)
   ...tseslint.configs.recommended,
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node
+      }
+    },
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off'
+    }
+  },
   // Configuration for Jest test files
   {
     files: ['**/__tests__/**/*.{js,ts,tsx}', '**/*.test.{js,ts,tsx}', '**/*.spec.{js,ts,tsx}'],


### PR DESCRIPTION
## Summary
- allow Node globals in script files
- disable require import rule for scripts

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a86b960718832190efd2b38ddb4524